### PR TITLE
Disable C# truncation with the R format specifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,8 @@
 	<!-- С# -->
 	<tr>
 		<td>C#</td>
-		<td><code>Console.WriteLine(.1 + .2);</code></td>
-		<td>0.3</td>
+		<td><code>Console.WriteLine("{0:R}", .1 + .2);</code></td>
+		<td>0.30000000000000004</td>
 	</tr>
 	<!-- GHC (Haskell) -->
 	<tr>


### PR DESCRIPTION
In C#, `Console.WriteLine(.1 + .2)` [calls](https://msdn.microsoft.com/en-us/library/219hw6yx.aspx) the [`ToString()`](https://msdn.microsoft.com/en-us/library/3hfd35ad.aspx) on Double, which formats the number using the general format specifier "G", which in turn [truncates doubles](https://msdn.microsoft.com/en-us/library/dwhawy9k.aspx#GFormatString) at the fifteenth significant digit. Using the round-trip format specifier "R" forces rendering the [full precision](https://msdn.microsoft.com/en-us/library/dwhawy9k.aspx#RFormatString).