### PR TITLE
Link to most recent Ruby version of bigdecimal

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
 			<a href="http://ruby-doc.org/core/classes/Rational.html">Rational</a>.
 			<br />
 			Ruby also has a library specifically for decimals:
-			<a href="http://ruby-doc.org/stdlib-1.9.3/libdoc/bigdecimal/rdoc/index.html">BigDecimal</a>.
+			<a href="http://ruby-doc.org/stdlib/libdoc/bigdecimal/rdoc/index.html">BigDecimal</a>.
 		</td>
 	</tr>
 	<!-- Python 2 -->


### PR DESCRIPTION
The link will auto redirect to the most recent Rubydoc version.