### PR TITLE
Correct Julia rational numbers code example

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,17 +180,13 @@ int main(int argc, char** argv) {
 		<td colspan="3" class="comment">
 			Julia has built-in
 			<a href="http://docs.julialang.org/en/release-0.4/manual/complex-and-rational-numbers/#rational-numbers">rational numbers support</a>
-			and also built-in
+			and also a built-in
 			<a href="http://docs.julialang.org/en/release-0.4/manual/integers-and-floating-point-numbers/#arbitrary-precision-arithmetic">arbitrary-precision BigFloat</a> data type.
+            To get the math right,
+            <code>1//10 + 2//10</code> returns <code>3//10</code>.
 		</td>
 	</tr>
 	<!-- Clojure -->
-	<tr>
-		<td colspan="3" class="comment">
-			Clojure supports rational numbers. To get the math right,
-			<code>(+ 1/10 2/10)</code> returns <code>3/10</code>.
-		</td>
-	</tr>
 	<tr>
 		<td>Clojure</td>
 		<td><code>(+ 0.1 0.2)</code></td>


### PR DESCRIPTION
For the Julia section, the code example for rational numbers had been an exact copy from
the Clojure example, which was probably a mistake while editing. This is hinted by the <!-- Clojure --> comment marker being in the Julia section, before the clojure tag. Corrected the example, comment position, and did a small grammar correction.

