### PR TITLE
Add rational example for rust

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,6 +286,8 @@ std::cout << setprecision(17) << 0.1 + 0.2 << std.endl;</pre></code></td>
 		<td>Rust</td>
 		<td>
 			<code><pre>
+extern crate num;
+use num::rational::Ratio;
 fn main() {
 	println!(.1+.2);
 	println!("1/10 + 2/10 = {}", Ratio::new(1, 10) + Ratio::new(2, 10));

--- a/index.html
+++ b/index.html
@@ -27,22 +27,22 @@
 		This representation comes with some degree of inaccuracy.
 		That's why, more often than not, <code>.1 + .2 != .3</code>.
 	</p>
-	
+
 	<h3>Why does this happen?</h3>
 	<p>
-		It's actually pretty simple. When you have a base 10 system (like ours), 
-		it can only express fractions that use a prime factor of the base. 
-		The prime factors of 10 are 2 and 5. So 1/2, 1/4, 1/5, 1/8, and 1/10 
-		can all be expressed cleanly because the denominators all use prime factors of 10. 
+		It's actually pretty simple. When you have a base 10 system (like ours),
+		it can only express fractions that use a prime factor of the base.
+		The prime factors of 10 are 2 and 5. So 1/2, 1/4, 1/5, 1/8, and 1/10
+		can all be expressed cleanly because the denominators all use prime factors of 10.
 		In contrast, 1/3, 1/6, and 1/7 are all repeating decimals because their denominators use a prime factor of 3 or 7.
-		In binary (or base 2), the only prime factor is 2. So you can only express fractions cleanly which only contain 2 as a prime factor. 
-		In binary, 1/2, 1/4, 1/8 would all be expressed cleanly as decimals. 
+		In binary (or base 2), the only prime factor is 2. So you can only express fractions cleanly which only contain 2 as a prime factor.
+		In binary, 1/2, 1/4, 1/8 would all be expressed cleanly as decimals.
 		While, 1/5 or 1/10 would be repeating decimals.
-		So 0.1 and 0.2 (1/10 and 1/5) while clean decimals in a base 10 system, are repeating decimals in the base 2 system the computer is operating in. 
-		When you do math on these repeating decimals, you end up with leftovers which carry 
+		So 0.1 and 0.2 (1/10 and 1/5) while clean decimals in a base 10 system, are repeating decimals in the base 2 system the computer is operating in.
+		When you do math on these repeating decimals, you end up with leftovers which carry
 		over when you convert the computer's base 2 (binary) number into a more human readable base 10 number.
 	</p>
-	
+
 	<p>
 		Below are some examples of sending <code>.1 + .2</code>
 		to standard output in a variety of languages.
@@ -288,10 +288,20 @@ std::cout << setprecision(17) << 0.1 + 0.2 << std.endl;</pre></code></td>
 			<code><pre>
 fn main() {
 	println!(.1+.2);
+	println!("1/10 + 2/10 = {}", Ratio::new(1, 10) + Ratio::new(2, 10));
 }</pre></code>
 		</td>
 		<td>
-			0.30000000000000004
+			0.30000000000000004<br />
+			3/10
+		</td>
+	</tr>
+	<tr>
+		<td colspan="3" class="comment">
+			Rust has
+			<a href="https://doc.rust-lang.org/num/num/rational/struct.Ratio.html">rational number support</a>
+			from the
+			<a href="https://doc.rust-lang.org/num/num/index.html">num create</a>.
 		</td>
 	</tr>
 	<!-- Emacs Lisp -->
@@ -416,8 +426,8 @@ func main() {
 			<code>scala -e 'println(0.1F + 0.2F)'</code>
 			And<br />
 			<code>scala -e 'println(BigDecimal("0.1") + BigDecimal("0.2"))'</code>
-			
-		</td>   
+
+		</td>
 		<td>
 			0.30000000000000004<br />
 			And<br />

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@ fn main() {
 			Rust has
 			<a href="https://doc.rust-lang.org/num/num/rational/struct.Ratio.html">rational number support</a>
 			from the
-			<a href="https://doc.rust-lang.org/num/num/index.html">num create</a>.
+			<a href="https://doc.rust-lang.org/num/num/index.html">num crate</a>.
 		</td>
 	</tr>
 	<!-- Emacs Lisp -->


### PR DESCRIPTION
Looks like my editor had removal of trailing whitespace turned on. Let me know if this is an issue.