### PR TITLE
Make println represent what is reported as the resultant output

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@ extern crate num;
 use num::rational::Ratio;
 fn main() {
 	println!(.1+.2);
-	println!("1/10 + 2/10 = {}", Ratio::new(1, 10) + Ratio::new(2, 10));
+	println!("{}", Ratio::new(1, 10) + Ratio::new(2, 10));
 }</pre></code>
 		</td>
 		<td>


### PR DESCRIPTION
I realized that my println statement was not printing just 3/10 but instead the extra 1/10 + 2/10. Fixed now.
