### PR TITLE
perl[56]: use more idiomatic syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,8 +394,8 @@ func main() {
 	<tr>
 		<td>Perl 5</td>
 		<td>
-			<code>perl -E 'say 0.1+0.2'</code><br />
-			<code>perl -e 'printf q{%.17f}, 0.1+0.2'</code>
+			<code>perl -E 'say 0.1 + 0.2'</code><br />
+			<code>perl -e 'printf "%.17f\n", 0.1 + 0.2'</code>
         </td>
 		<td>
 			0.3<br />
@@ -406,9 +406,9 @@ func main() {
 	<tr>
 		<td>Perl 6</td>
 		<td>
-			<code>perl6 -e 'say 0.1+0.2'</code><br />
-			<code>perl6 -e 'say sprintf(q{%.17f}, 0.1+0.2)'</code><br />
-			<code>perl6 -e 'say 1/10+2/10'</code>
+			<code>perl6 -e 'say 0.1 + 0.2'</code><br />
+			<code>perl6 -e 'printf "%.17f\n", 0.1 + 0.2'</code><br />
+			<code>perl6 -e 'say 1 / 10+2 / 10'</code>
 		</td>
 		<td>
 			0.3<br />


### PR DESCRIPTION
Improve the examples added in commit 984f3ba ("Added Perl sample",
2014-12-04) for Perl 5 and commit 5322f45 ("Add Perl 6 and mark "Perl"
as "Perl 5"", 2015-11-13) for Perl 6 so that:

 * They use whitespace between numbers & operators like most of the
   other examples.

 * Don't needlessly use the q{} construct when "" would do.

 * There's no need to "say sprintf", we can just "printf" with a
   newline, also add a \n to the Perl 5 example for consistency.