### PR TITLE
Add info on decimal and rational support in Python

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,11 +148,9 @@ std::cout << setprecision(17) << 0.1 + 0.2 << std.endl;</pre></code></td>
 		<td>
 			<code>print(.1 + .2)</code><br />
 			And<br />
-			<code>float(decimal.Decimal(".1") + decimal.Decimal(".2"))</code>
-			And<br />
 			<code>.1 + .2</code>
 		</td>
-		<td>0.3<br />And<br />0.3<br/>And<br />0.30000000000000004</td>
+		<td>0.3<br />And<br />0.30000000000000004</td>
 	</tr>
 	<tr>
 		<td colspan="3" class="comment">
@@ -168,6 +166,14 @@ std::cout << setprecision(17) << 0.1 + 0.2 << std.endl;</pre></code></td>
 			<code>.1 + .2</code>
 		</td>
 		<td>0.30000000000000004<br />And<br />0.30000000000000004</td>
+	</tr>
+	<tr>
+		<td colspan="3" class="comment">
+			Python (both 2 and 3) supports decimal arithmetic with the
+			<a href="https://docs.python.org/3/library/decimal.html">decimal</a> module,
+			and true rational numbers with the
+			<a href="https://docs.python.org/3.7/library/fractions.html">fractions</a> module.
+		</td>
 	</tr>
 	<!-- Lua -->
 	<tr>


### PR DESCRIPTION
* Removed the example with `decimal.Decimal`, as it doesn't seem to follow the form of the other languages
* Added information on both the `decimal` and `fractions` modules.