### PR TITLE
Fixes Objective-C example

### DIFF
--- a/_posts/2017-04-30-objective-c.md
+++ b/_posts/2017-04-30-objective-c.md
@@ -1,6 +1,13 @@
 ---
 layout: post
 title: "Objective-C"
-code: '0.1 + 0.2;'
-result: '0.300000012'
+code: |-
+    #import <Foundation/Foundation.h>
+	int main(int argc, const char * argv[]) {
+        @autoreleasepool {
+            NSLog(@"%.17f\n", .1+.2);
+        }
+        return 0;
+    }
+result: 0.30000000000000004
 ---


### PR DESCRIPTION
Example provided is misleading.
It's not full Objective-C program, like C.
And provided output is incorrect.
Example in pull request is full Objective-C program and it's structure and output matches those of C program which is expected because Objective-C is extension of C.