### PR TITLE
Fixes Swift example

### DIFF
--- a/_posts/2017-04-30-swift.md
+++ b/_posts/2017-04-30-swift.md
@@ -1,10 +1,5 @@
 ---
 layout: post
 title: "Swift"
-code:
-  - '0.1 + 0.2'
-  - 'NSString(format: "%.17f", 0.1 + 0.2)'
-result:
-  - '0.3'
-  - '0.30000000000000004'
----
+code: print(String(format: "%.17f", 0.1 + 0.2))
+result: 0.30000000000000004


### PR DESCRIPTION
- Removes first example 0.1 + 0.2 as not relevant;
- In second (now the only one) example uses String instead NSString and uses print to make example complete program as all other examples.