### PR TITLE
Add Double example for Visual Basic

### DIFF
--- a/_posts/2017-04-30-vbasic.md
+++ b/_posts/2017-04-30-vbasic.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "Visual Basic"
+code: |-
+  a# = 0.1 + 0.2: b# = 0.3
+  Debug.Print Format(a - b, "0." & String(16, "0"))
+  Debug.Print a = b
+result: |-
+  0.0000000000000001
+  False
+---
+Appending the identifier type character # to any identifier forces it to Double.


### PR DESCRIPTION
The Double type is used in:
- MS Visual Basic 6
- MS Visual Basic 7
- MS Visual Basic for Application