### PR TITLE
Add 0.3 to Crystal

### DIFF
--- a/_posts/2017-04-30-crystal.md
+++ b/_posts/2017-04-30-crystal.md
@@ -1,7 +1,10 @@
 ---
 layout: post
 title: 'Crystal'
-code: |-
-  puts 0.1 + 0.2
-result: 0.30000000000000004
+code: 
+  - puts 0.1 + 0.2
+  - puts 0.1_f32 + 0.2_f32
+result:
+  - 0.30000000000000004
+  - 0.3
 ---


### PR DESCRIPTION
One note:
`puts 0.1f_32 + 0.2_f32` is the same as `puts 0.1f32 + 0.2f32`, but reading better. I can add the second option if required

[Crystal's Floats](https://crystal-lang.org/reference/syntax_and_semantics/literals/floats.html)