### PR TITLE
Fix broken URL to resource about IEEE 754

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -35,7 +35,7 @@ layout: default
         |
         <a href="http://en.wikipedia.org/wiki/Floating_point">wikipedia</a>
         |
-        <a href="https://en.wikipedia.org/wiki/IEEE_754">IEEE 754</a>
+        <a href="https://web.archive.org/web/20180419150129/http://grouper.ieee.org/groups/754/">IEEE 754</a>
         |
         <a href="http://stackoverflow.com/questions/588004/is-javascripts-math-broken/588014">Stack Overflow</a>
         |

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -35,7 +35,7 @@ layout: default
         |
         <a href="http://en.wikipedia.org/wiki/Floating_point">wikipedia</a>
         |
-        <a href="https://web.archive.org/web/20180419150129/http://grouper.ieee.org/groups/754/">IEEE 754</a>
+        <a href="https://standards.ieee.org/standard/754-2008.html">IEEE 754</a>
         |
         <a href="http://stackoverflow.com/questions/588004/is-javascripts-math-broken/588014">Stack Overflow</a>
         |

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -35,7 +35,7 @@ layout: default
         |
         <a href="http://en.wikipedia.org/wiki/Floating_point">wikipedia</a>
         |
-        <a href="http://grouper.ieee.org/groups/754/">IEEE 754</a>
+        <a href="https://en.wikipedia.org/wiki/IEEE_754">IEEE 754</a>
         |
         <a href="http://stackoverflow.com/questions/588004/is-javascripts-math-broken/588014">Stack Overflow</a>
         |


### PR DESCRIPTION
The article's last available revision was retrieved using the [Internet Archive's Wayback Machine](https://web.archive.org).