### PR TITLE
Improve Python examples

### DIFF
--- a/_posts/2017-04-30-python2.md
+++ b/_posts/2017-04-30-python2.md
@@ -3,11 +3,14 @@ layout: post
 title: "Python 2"
 code:
   - 'print(.1 + .2)'
-  - 'float(decimal.Decimal(".1") + decimal.Decimal(".2"))'
   - '.1 + .2'
+  - 'float(decimal.Decimal(".1") + decimal.Decimal(".2"))'
+  - 'float(fractions.Fraction('0.1') + fractions.Fraction('0.2'))'
+
 result:
   - 0.3
-  - 0.3
   - 0.30000000000000004
+  - 0.3
+  - 0.3
 ---
 Python 2's "print" statement converts 0.30000000000000004 to a string and shortens it to "0.3". To achieve the desired floating point result, use print(repr(.1 + .2)). This was fixed in Python 3 (see below).

--- a/_posts/2017-04-30-python3.md
+++ b/_posts/2017-04-30-python3.md
@@ -4,8 +4,12 @@ title: "Python 3"
 code:
   - print(.1 + .2)
   - .1 + .2
+  - float(decimal.Decimal('.1') + decimal.Decimal('.2'))
+  - float(fractions.Fraction('0.1') + fractions.Fraction('0.2'))
 result:
   - 0.30000000000000004
   - 0.30000000000000004
+  - 0.3
+  - 0.3
 ---
 Python (both 2 and 3) supports decimal arithmetic with the [decimal](https://docs.python.org/3/library/decimal.html) module, and true rational numbers with the [fractions](https://docs.python.org/3.7/library/fractions.html) module.


### PR DESCRIPTION
This adds fractional examples from Python, moves the non-floating point examples below the fp examples, and adds the Decimal example to the Python 3 item.