### PR TITLE
Add WebAssembly (WAST)

### DIFF
--- a/_posts/2017-04-30-wast.md
+++ b/_posts/2017-04-30-wast.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title:  "WebAssembly (WAST)"
+code:
+    - |-
+        (func $add_f32 (result f32)
+            f32.const 0.1
+            f32.const 0.2
+            f32.add)
+        (export "add_f32" (func $add_f32))
+    - |-
+        (func $add_f64 (result f64)
+            f64.const 0.1
+            f64.const 0.2
+            f64.add)
+        (export "add_f64" (func $add_f64))
+result:
+    - 0.30000001192092896
+    - 0.30000000000000004
+---
+https://webassembly.studio/?f=mrhzi548g37

--- a/_posts/2017-04-30-wast.md
+++ b/_posts/2017-04-30-wast.md
@@ -18,4 +18,4 @@ result:
     - 0.30000001192092896
     - 0.30000000000000004
 ---
-https://webassembly.studio/?f=mrhzi548g37
+https://webassembly.studio/?f=r739k6d6q4t


### PR DESCRIPTION
Added WebAssembly example (using WAST/WAT, the text format). Since WebAssembly has no support for print or logging built in I created the examples as exported function. I added a link to webassembly.studio to check the results.