### PR TITLE
Specify foreground colors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@ body {
 	font-family: sans-serif;
 	font-size: 12px;
 	background: #9CF url('/white-to-blue.gif') top left repeat-x;
+	color: #000;
 }
 
 div {
@@ -56,4 +57,12 @@ pre {
 p {
     margin: 0;
     overflow: auto;
+}
+
+a {
+    color: #00F;
+}
+
+a:visited {
+    color: #80F;
 }


### PR DESCRIPTION
Added default colors for text, links and visited hyperlinks. If these are not specified, the browser will fall back to its default colors. Often these are black on white, with blue and purple hyperlinks. But they can be changed by the user.

See also: https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use#w_change-font-color

### Before:

![screenshot_2019-12-03T06-33-21](https://user-images.githubusercontent.com/3681516/70023311-5a73b980-1597-11ea-8cb7-d2ba254e68c9.png)

### After:

![screenshot_2019-12-03T06-39-26](https://user-images.githubusercontent.com/3681516/70023401-af173480-1597-11ea-96a1-557da501f643.png)
