### PR TITLE
c++: fix example not compiling

### DIFF
--- a/_posts/2017-04-30-cpp.md
+++ b/_posts/2017-04-30-cpp.md
@@ -3,6 +3,9 @@ layout: post
 title: "C++"
 code: |-
     #include <iomanip>
-    std::cout << std::setprecision(17) << 0.1 + 0.2
+    #include <iostream>
+    int main() {
+        std::cout << std::setprecision(17) << 0.1 + 0.2;
+    }
 result: 0.30000000000000004
 ---


### PR DESCRIPTION
add missing iostream, main function and missing semicolon