### PR TITLE
Point Ruby BigDecimal to a page with info on

### DIFF
--- a/_posts/2017-04-30-ruby.md
+++ b/_posts/2017-04-30-ruby.md
@@ -9,4 +9,4 @@ result:
   - 3/10
 ---
 Ruby supports rational numbers in syntax with version 2.1 and newer directly. For older versions use [Rational](http://ruby-doc.org/core/classes/Rational.html).  
-Ruby also has a library specifically for decimals: [BigDecimal](http://ruby-doc.org/stdlib/libdoc/bigdecimal/rdoc/index.html).
+Ruby also has a library specifically for decimals: [BigDecimal](https://ruby-doc.org/stdlib-2.6.5/libdoc/bigdecimal/rdoc/BigDecimal.html).

--- a/_posts/2017-04-30-ruby.md
+++ b/_posts/2017-04-30-ruby.md
@@ -9,4 +9,4 @@ result:
   - 3/10
 ---
 Ruby supports rational numbers in syntax with version 2.1 and newer directly. For older versions use [Rational](http://ruby-doc.org/core/classes/Rational.html).  
-Ruby also has a library specifically for decimals: [BigDecimal](https://ruby-doc.org/stdlib-2.6.5/libdoc/bigdecimal/rdoc/BigDecimal.html).
+Ruby also has a library specifically for decimals: [BigDecimal](https://ruby-doc.org/stdlib/libdoc/bigdecimal/rdoc/BigDecimal.html).


### PR DESCRIPTION
Nice website - thanks for making it :)

The current link to Ruby BigDecimal goes to a page listing the library classes/methods without any explanation as to the BigDecimal class or how to use it. This new link takes you directly to the BigDecimal page, which explains the concepts, how to use it, and everything else that is listed on the original page.