### PR TITLE
csharp: add float type example

### DIFF
--- a/_posts/2017-04-30-csharp.md
+++ b/_posts/2017-04-30-csharp.md
@@ -3,9 +3,11 @@ layout: post
 title: "C#"
 code: 
   - Console.WriteLine("{0:R}", .1 + .2);
+  - Console.WriteLine("{0:R}", .1f + .2f);
   - Console.WriteLine("{0:R}", .1m + .2m);
 result:
   - 0.30000000000000004
+  - 0.3
   - 0.3
 ---
 [C# has support for 128-bit decimal numbers](https://msdn.microsoft.com/en-us/library/364x0z75.aspx), with 28-29 significant digits of precision. Their range, however, is smaller than that of both the single and double precision floating point types. Decimal literals are denoted with the `m` suffix.


### PR DESCRIPTION
There are three floating-point types in C#. The `double` and `decimal` were already shown. This PR adds the `float` type too.