### PR TITLE
Update 2017-04-30-swift.md

### DIFF
--- a/_posts/2017-04-30-swift.md
+++ b/_posts/2017-04-30-swift.md
@@ -3,8 +3,9 @@ layout: post
 title: "Swift"
 code:
   - '0.1 + 0.2'
-  - 'NSString(format: "%.17f", 0.1 + 0.2)'
+  - 'Decimal(0.1) + Decimal(0.2)'
 result:
-  - '0.3'
   - '0.30000000000000004'
+  - '0.3'
 ---
+Swift supports decimal arithmetic with the [Foundation](https://developer.apple.com/documentation/foundation/decimal) module.


### PR DESCRIPTION
This PR fixes the `Double` result and adds `Decimal` example.