### PR TITLE
Update 2017-04-30-php.md

### DIFF
--- a/_posts/2017-04-30-php.md
+++ b/_posts/2017-04-30-php.md
@@ -7,7 +7,7 @@ code: |-
     var_dump(bcadd(.1, .2, 1));
 result: |-
     0.3 
-    float(0.30000000000000004441)
+    float(0.3)
     string(3) "0.3"
 ---
 PHP `echo` converts 0.30000000000000004441 to a string and shortens it to "0.3". To achieve the desired floating point result, adjust the precision ini setting: ini_set("precision", 17).


### PR DESCRIPTION
I think the var dump is showing wrong all the test I have done in PHP 5.6.4 and 7.3.5 all show `float(0.3)`