### PR TITLE
Python 2 print = statement

### DIFF
--- a/_posts/2017-04-30-python-2.md
+++ b/_posts/2017-04-30-python-2.md
@@ -1,7 +1,7 @@
 ---
 title: Python 2
 code:
-  - print(.1 + .2)
+  - print .1 + .2
   - .1 + .2
   - float(decimal.Decimal(".1") + decimal.Decimal(".2"))
   - float(fractions.Fraction('0.1') + fractions.Fraction('0.2'))
@@ -14,4 +14,4 @@ result:
 
 Python 2's `print` statement converts `0.30000000000000004` to a string and
 shortens it to "0.3". To achieve the desired floating point result, use
-`print(repr(.1 + .2))`. This was fixed in Python 3 (see below).
+`print repr(.1 + .2)`. This was fixed in Python 3 (see below).


### PR DESCRIPTION
Removed () from 2x print statements not needed for the python 2 example

Print is a statement, not a function in python 2, so simplifies the code