### PR TITLE
Fixes PowerShell square brackets formatting issue

### DIFF
--- a/_posts/2017-04-30-powershell.md
+++ b/_posts/2017-04-30-powershell.md
@@ -1,15 +1,15 @@
 ---
 title: PowerShell
-code: 
-  - 0.1 + 0.2
-  - 0.1 + 0.2 -eq 0.3
-  - [decimal]0.1 + [decimal]0.2 -eq [decimal]0.3
-  - 0.1d + 0.2d -eq 0.3d
-result: 
-  - 0.3
-  - False
-  - True
-  - True
+code: |-
+  0.1 + 0.2
+  0.1 + 0.2 -eq 0.3
+  [decimal]0.1 + [decimal]0.2 -eq [decimal]0.3
+  0.1d + 0.2d -eq 0.3d
+result: |-
+  0.3
+  False
+  True
+  True
 ---
 
 PowerShell by default uses double type, but because it runs on .NET it has the


### PR DESCRIPTION
Apparently having square brackets in listing is not possible.  I tried
different forms of escaping them using \\, `, [ and html codes without
success.  Only switching syntax from listing to the block helped.