### PR TITLE
Update Rust example Ratio struct url

### DIFF
--- a/_posts/2017-04-30-rust.md
+++ b/_posts/2017-04-30-rust.md
@@ -17,5 +17,5 @@ result: |-
 
 Rust has [rational number support][1] from the [num crate][2].
 
-[1]: https://rust-num.github.io/num/num_rational/struct.Ratio.html
+[1]: https://docs.rs/num/latest/num/rational/struct.Ratio.html
 [2]: https://crates.io/crates/num


### PR DESCRIPTION
Current link is broken, change to the url of latest version in doc.rs.