### PR TITLE
Simplify Vala sample

### DIFF
--- a/_posts/2017-04-30-vala.md
+++ b/_posts/2017-04-30-vala.md
@@ -1,9 +1,8 @@
 ---
 title: Vala
 code: |-
-  static int main(string[] args) {
-    stdout.printf("%.17f\n", 0.1 + 0.2);
-    return 0;
+  void main () {
+    print (@"$(0.1 + 0.2)\n");
   }
 result: 0.30000000000000004
 ---


### PR DESCRIPTION
- The `main ()` function can return `void` on Vala
- String templates can produce the same result, so no need to use printf format strings
- `GLib.print ()` is a shortcut for `stdout.printf ()`, so use that
- The `GLib` namespace is imported by default on Vala, so no need to specify it when calling `GLib.print ()`