### PR TITLE
Move rational number operation to table

### DIFF
--- a/_posts/2017-04-30-julia.md
+++ b/_posts/2017-04-30-julia.md
@@ -1,12 +1,15 @@
 ---
 title: Julia
-code: .1 + .2
-result: 0.30000000000000004
+code: 
+  - .1 + .2
+  - 1//10 + 2//10
+result: 
+  - 0.30000000000000004
+  - 3//10
 ---
 
 Julia has built-in [rational numbers support][1] and also a built-in
-[arbitrary-precision BigFloat][2] data type. To get the math right, `1//10 +
-2//10` returns `3//10`.
+[arbitrary-precision BigFloat][2] data type. 
 
 [1]: https://docs.julialang.org/en/v1/manual/complex-and-rational-numbers/#Rational-Numbers-1
 [2]: https://docs.julialang.org/en/v1/manual/integers-and-floating-point-numbers/#Arbitrary-Precision-Arithmetic-1


### PR DESCRIPTION
To be consistent with how other languages are presented, move the rational number code example to the table.