### PR TITLE
Fix typo on gforth example

### DIFF
--- a/_posts/2017-04-30-gforth.md
+++ b/_posts/2017-04-30-gforth.md
@@ -10,5 +10,5 @@ result:
   - -1
 ---
 
-In Gforth `0` means `false` and `-1` means `true`. First example print
-`0.3` but it's not equal to actuall `0.3`.
+In Gforth `0` means `false` and `-1` means `true`. First example prints
+`0.3` but it's not equal to actual `0.3`.


### PR DESCRIPTION
Fixed typo (actuall -> actual) and a small edit for clarity: “first example print 0.3 -> first example prints 0.3