### PR TITLE
Adds an example in COBOL

### DIFF
--- a/_posts/2024-04-01-cobol.md
+++ b/_posts/2024-04-01-cobol.md
@@ -1,0 +1,23 @@
+---
+title: COBOL
+code: |-
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. HFPMATH.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       77 X-32 USAGE COMP-1.
+       77 X-64 USAGE COMP-2.
+       PROCEDURE DIVISION.
+           COMPUTE X-32 = 0.1 + 0.2.
+           DISPLAY X-32.
+           COMPUTE X-64 = 0.1 + 0.2.
+           DISPLAY X-64.
+           MOVE 0.1 TO X-64.
+           DISPLAY X-64.
+result: |-
+ 0.30000001
+ 0.3
+ 0.09999999999999999"
+---
+
+COBOL encodes floating-point numbers using the HFP format instead of IEEE754, leading to different but analogous computation innacuracies.

--- a/_posts/2024-04-01-cobol.md
+++ b/_posts/2024-04-01-cobol.md
@@ -17,7 +17,9 @@ code: |-
 result: |-
  0.30000001
  0.3
- 0.09999999999999999"
+ 0.09999999999999999
 ---
 
-COBOL encodes floating-point numbers using the HFP format instead of IEEE754, leading to different but analogous computation innacuracies.
+COBOL encodes floating-point numbers using the [HFP][1] format instead of IEEE754, leading to different but analogous computation inaccuracies.
+
+[1]: https://en.wikipedia.org/wiki/IBM_hexadecimal_floating-point


### PR DESCRIPTION
Hi,
I've added an example of floating point computations in COBOL. The yielded result differes from the usual 0.300...04 because COBOL uses the HFP format for floating point numbers instead of IEEE754, but the same mechanism is at play behind the scenes.
When using 64-bits HFP floats, 0.1 + 0.2 actually resolves to 0.3. But 0.1 cannot be correctly represented and resolves to 0.09999999. I thought it was relevant to add it to the example
I've tried to keep the code snippest as small as possible, but COBOL isn't really renowned for its conciseness :-)
Let me know if you think it deserves any edition
Thanks !