### PR TITLE
Fix formatting issue in Powershell example

### DIFF
--- a/_posts/2017-04-30-powershell.md
+++ b/_posts/2017-04-30-powershell.md
@@ -1,11 +1,11 @@
 ---
 title: PowerShell
-code: 
+code: |-
   - 0.1 + 0.2
   - 0.1 + 0.2 -eq 0.3
   - [decimal]0.1 + [decimal]0.2 -eq [decimal]0.3
   - 0.1d + 0.2d -eq 0.3d
-result: 
+result: |-
   - 0.3
   - False
   - True


### PR DESCRIPTION
`bundle exec jekyll serve` was giving me a warning about the PowerShell example file, which made me realize that it was not even rendered correctly on the page that is served on https://0.30000000000000004.com/ . This should now be fixed