### PR TITLE
Numbat: clarify that `.1 + .2` is not actually `.3` despite how it's displayed

### DIFF
--- a/_posts/2025-07-26-numbat.md
+++ b/_posts/2025-07-26-numbat.md
@@ -2,8 +2,12 @@
 title: Numbat
 code:
   - .1 + .2
+  - .1 + .2 == .3
+  - .1 + .2 - .3
 result:
   - 0.3
+  - false
+  - 5.55112e-17
 ---
 
 [Numbat][1] is a statically typed programming language for scientific computations with first class support for physical dimensions and units.


### PR DESCRIPTION
Follow-up to https://github.com/erikwiffin/0.30000000000000004/pull/255
See [my comment](https://github.com/erikwiffin/0.30000000000000004/pull/255#pullrequestreview-4017369387) there.